### PR TITLE
Fix: Only block Twitterbot instead of *

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -157,11 +157,9 @@ function allow_twitterbot( string $output ) :string {
 		return $output;
 	}
 
-	$output = 'User-agent: Twitterbot
-Disallow:
-
-User-agent: *
-Disallow: /';
+	$output .= 'User-agent: Twitterbot
+Disallow: /
+';
 
 	return $output;
 }


### PR DESCRIPTION
This fixes interactions that occur when `$allow_twitter` is set to `false`:
1. Change `$output =` to `$output .=` to prevent the existing `$output` from being overwritten, instead just appending.
2. `Disallow:` to `Disallow: /` as the previous implementation actually blocked all crawlers (`*`) except Twitterbot.
3. Add a trailing newline to the appended text. We encountered an instance where the following line in robots.txt was added to the same line as the `Disallow`, causing the `Disallow` line to be incorrectly parsed.

Testing instructions:
1. Go to `Settings / Social Media Scheduling` and leave `Allow twitter Bot` unchecked
2. Compare resulting robots.txt to robots.txt prior to change on a robots.txt validator tool like [this one](https://technicalseo.com/tools/robots-txt/).
3. If unchecked, Twitterbot should be blocked, but the general site should be allowed.